### PR TITLE
@ #31 | should use domain aliases for dev and prod modes instead of ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,10 @@ PROJECT_NAME=angular-boilerplate
 PROJECT_VERSION=0.2.0-SNAPSHOT
 
 # for docker-compose.yml and docker-compose.prod.yml
-DEV_DOCKER_IMAGE=teracy/angular-boilerplate:dev_develop
-PROD_DOCKER_IMAGE=teracy/angular-boilerplate:develop
+DOCKER_IMAGE_DEV=teracy/angular-boilerplate:dev_develop
+DOCKER_IMAGE_PROD=teracy/angular-boilerplate:develop
+
+# for nginx-proxy to use domains instead of ports
+# see: https://github.com/teracyhq/angular-boilerplate/issues/31
+DOMAIN_DEV=dev.ab.teracy.dev
+DOMAIN_PROD=ab.teracy.dev

--- a/docker-compose.prod.tpl.yml
+++ b/docker-compose.prod.tpl.yml
@@ -13,5 +13,12 @@ services:
         - CI_REGISTRY_IMAGE=${CI_REGISTRY_IMAGE}
         - CI_PROJECT_NAME=${CI_PROJECT_NAME}
     image: ${DOCKER_IMAGE_PROD:-${DOCKER_IMAGE_PROD}}
+    environment:
+      VIRTUAL_HOST: ${DOMAIN_PROD}
+      HTTPS_METHOD: noredirect # support both http and https
     ports:
-      - 8080:80
+      - "80"
+    restart: unless-stopped
+    # to get this work with https://github.com/jwilder/nginx-proxy
+    # related: https://github.com/jwilder/nginx-proxy/issues/305
+    network_mode: bridge

--- a/docker-compose.tpl.yml
+++ b/docker-compose.tpl.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  
+
   dev:
     build:
       context: .
@@ -18,7 +18,13 @@ services:
     command: bash -c "yarn run start"
     environment:
       NODE_ENV: development
+      VIRTUAL_HOST: ${DOMAIN_DEV}
+      HTTPS_METHOD: noredirect # support both http and https
     volumes:
       - .:/opt/app
     ports:
-      - 4200:4200
+      - "4200"
+    restart: unless-stopped
+    # to get this work with https://github.com/jwilder/nginx-proxy
+    # related: https://github.com/jwilder/nginx-proxy/issues/305
+    network_mode: bridge

--- a/package.tpl.json
+++ b/package.tpl.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host=0.0.0.0",
+    "start": "ng serve --host=0.0.0.0 --liveReloadClient http://${DOMAIN_DEV}",
     "build": "ng build",
     "test": "ng test --browsers Chrome_no_sandbox",
     "lint": "ng lint",

--- a/setup.sh
+++ b/setup.sh
@@ -6,12 +6,12 @@ envsubst '${PROJECT_NAME}' <.angular-cli.tpl.json >.angular-cli.json
 
 # generate package.json
 rm -rf package.json
-envsubst '${PROJECT_NAME} ${PROJECT_VERSION}' <package.tpl.json >package.json
+envsubst '${PROJECT_NAME} ${PROJECT_VERSION} ${DOMAIN_DEV}' <package.tpl.json >package.json
 
 # generate docker-compose.yml
 rm -rf docker-compose.yml
-envsubst '${DOCKER_IMAGE_DEV}' <docker-compose.tpl.yml >docker-compose.yml
+envsubst '${DOCKER_IMAGE_DEV} ${DOMAIN_DEV}' <docker-compose.tpl.yml >docker-compose.yml
 
 # generate docker-compose.prod.yml
 rm -rf docker-compose.prod.yml
-envsubst '${DOCKER_IMAGE_PROD}' <docker-compose.prod.tpl.yml >docker-compose.prod.yml
+envsubst '${DOCKER_IMAGE_PROD} ${DOMAIN_PROD}' <docker-compose.prod.tpl.yml >docker-compose.prod.yml


### PR DESCRIPTION
Because ports fixed "4200:4200" or "8080:80" are easily conflicted with other services.

We should use nginx-proxy provided by teracy-dev to use domain aliases instead of fixed ports.

connects #31 